### PR TITLE
Leaderboard B - Windows Support (workaround)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## MDX-Net Track B Submission
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Ma5onic/mdx-net-submission/leaderboard_B)
 
 This branch contains the source code and the pretrained model that is submitted to the [Sony MDX Challenge](https://www.aicrowd.com/challenges/music-demixing-challenge-ismir-2021) Track B.
 

--- a/evaluator/music_demixing.py
+++ b/evaluator/music_demixing.py
@@ -10,6 +10,7 @@ import signal
 from contextlib import contextmanager
 from os import listdir
 from os.path import isfile, join
+from sys import platform
 
 import soundfile as sf
 import numpy as np
@@ -21,15 +22,18 @@ class TimeoutException(Exception): pass
 
 @contextmanager
 def time_limit(seconds):
-    def signal_handler(signum, frame):
-        raise TimeoutException("Prediction timed out!")
+    if platform != "win32":
+        def signal_handler(signum, frame):
+            raise TimeoutException("Prediction timed out!")
 
-    signal.signal(signal.SIGALRM, signal_handler)
-    signal.alarm(seconds)
-    try:
+            signal.signal(signal.SIGALRM, signal_handler)
+            signal.alarm(seconds)
+            try:
+                yield
+            finally:
+                signal.alarm(0)
+    else:
         yield
-    finally:
-        signal.alarm(0)
 
 
 class MusicDemixingPredictor:

--- a/predict_blend.py
+++ b/predict_blend.py
@@ -57,7 +57,10 @@ class Predictor(MusicDemixingPredictor):
                 tar_signal = tar_waves[:,:,trim:-trim].transpose(0,1).reshape(2, -1).numpy()[:, :-pad]
         
             sources.append(tar_signal)
+        print("\n======================================")
+        print("Time to execute demix_base(self, mix):")
         print(time()-start_time)
+        print("======================================\n")
         return np.array(sources)
     
     def demix_demucs(self, mix):
@@ -71,7 +74,10 @@ class Predictor(MusicDemixingPredictor):
             
         sources = (sources * ref.std() + ref.mean()).cpu().numpy()
         sources[[0,1]] = sources[[1,0]]
+        print("\n========================================")
+        print("Time to execute demix_demucs(self, mix):")
         print(time() - start_time)
+        print("========================================\n")
         return sources
         
 


### PR DESCRIPTION
This PR is to implement [the workaround that I found](https://github.com/kuielab/mdx-net-submission/issues/1#issuecomment-1214600796) for windows users to resolve open issue https://github.com/kuielab/mdx-net-submission/issues/1 by providing a workaround until a permanent solution is found.

Improvements can be made by using a different library to chose the timeout length.
For more info on why this library doesn't work with Windows, see last paragraph of `signal.signal(signalnum, handler)` documentation: https://docs.python.org/3.9/library/signal.html#signal.signal
> On Windows, [signal()](https://docs.python.org/3.9/library/signal.html#module-signal) can only be called with [SIGABRT](https://docs.python.org/3.9/library/signal.html#signal.SIGABRT), [SIGFPE](https://docs.python.org/3.9/library/signal.html#signal.SIGFPE), [SIGILL](https://docs.python.org/3.9/library/signal.html#signal.SIGILL), [SIGINT](https://docs.python.org/3.9/library/signal.html#signal.SIGINT), [SIGSEGV](https://docs.python.org/3.9/library/signal.html#signal.SIGSEGV), [SIGTERM](https://docs.python.org/3.9/library/signal.html#signal.SIGTERM), or [SIGBREAK](https://docs.python.org/3.9/library/signal.html#signal.SIGBREAK). A [ValueError](https://docs.python.org/3.9/library/exceptions.html#ValueError) will be raised in any other case. Note that not all systems define the same set of signal names; an [AttributeError](https://docs.python.org/3.9/library/exceptions.html#AttributeError) will be raised if a signal name is not defined as SIG* module level constant.